### PR TITLE
fix: correct unionOffest typo to unionOffset

### DIFF
--- a/src/Database/Query/Builder.php
+++ b/src/Database/Query/Builder.php
@@ -167,7 +167,7 @@ class Builder extends \Illuminate\Database\Query\Builder
                 'offset',
                 'unions',
                 'unionLimit',
-                'unionOffest',
+                'unionOffset',
                 'unionOrders',
                 'lock',
              ] as $component) {


### PR DESCRIPTION
## Summary
Fixes a typo in the property name `unionOffest` → `unionOffset` that causes PHP 8.2+ deprecation warnings on every database query.

## Problem
Running any database query on PHP 8.2+ produces deprecation warnings:

```
PHP Deprecated: Creation of dynamic property 
AngelSourceLabs\LaravelExpressions\Database\Query\Builder::$unionOffest is deprecated
in src/Database/Query/Builder.php on line 174

```
This happens because line 170 contains a typo: `'unionOffest'` instead of `'unionOffset'`. Laravel's Query Builder has a property called `$unionOffset` (correct spelling), but the code tries to access `$unionOffest` (typo), creating a non-existent dynamic property.